### PR TITLE
Allow subscription to service events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('vantiqSdkVersion')) {
-        vantiqSdkVersion = '1.0.2'
+        vantiqSdkVersion = '1.1.0'
     }
 }
 
@@ -127,6 +127,8 @@ task copyTestResources() {
 task pyclean(type: Delete) {
     delete "${project.projectDir}/build"
     delete "${project.projectDir}/dist"
+    // Also delete generated stuff
+    delete "${project.projectDir}/setup.cfg"
 }
 
 task publish(type: PythonTask) {

--- a/docs/api.md
+++ b/docs/api.md
@@ -514,6 +514,9 @@ source is required (_e.g._, `MySource`).
 For topics, this will subscribe to any messages published on that topic.  The
 name of the topic is required (_e.g._, `/some/topic`).
 
+For services, this will subscribe to any messages published to the named service event. The name of the
+service and service event is required, and should be passed into the resource id as service_name/event_name.
+
 For types, this will subscribe to the specified type event.  The name of the
 type and the operation (_i.e._, `insert`, `update`, or `delete`) are required.
 

--- a/src/main/python/vantiqsdk.py
+++ b/src/main/python/vantiqsdk.py
@@ -1223,13 +1223,16 @@ class Vantiq:
                         callback: Callable[[str, dict], Awaitable[None]], params: dict) -> VantiqResponse:
         """(Async) Subscribe to an event from the Vantiq server.
 
-        Subscribes to a specific topic, source, or type event.
+        Subscribes to a specific topic, source, service, or type event.
 
         For sources, this will subscribe to message arrival events.  The name of the
         source is required (e.g. "MySource").
 
         For topics, this will subscribe to any messages published on that topic.  The
         name of the topic is required (e.g. "/some/topic").
+
+        For services, this will subscribe to any messages published to the named service event. The name of the
+        service and service event is required, and should be passed into the resource id as service_name/event_name.
 
         For types, this will subscribe to the specified type event.  The name of the
         type and the operation (i.e. "insert", "update", or "delete") are required.
@@ -1264,7 +1267,7 @@ class Vantiq:
             path = "/" + resource[len(_SYSTEM_PREFIX):] + resource_id  # .removeprefix(_SYSTEM_PREFIX) + resource_id
         else:
             path = "/" + resource[len(_SYSTEM_PREFIX):] + '/' + resource_id  # .removeprefix(_SYSTEM_PREFIX) ...
-        if resource in [VantiqResources.SOURCES, VantiqResources.TOPICS]:
+        if resource in [VantiqResources.SERVICES, VantiqResources.SOURCES, VantiqResources.TOPICS]:
             if operation:
                 raise VantiqException('io.vantiq.python.operationillegal',
                                       "Operation only support for {0}",
@@ -1278,7 +1281,7 @@ class Vantiq:
             path += "/" + operation.lower()
         else:
             raise VantiqException('io.vantiq.python.invalidsubscribetype',
-                                  "Only 'topics', 'sources' and 'types' support subscribe",
+                                  "Only 'topics', 'sources', 'services', and 'types' support subscribe",
                                   [])
 
         if self._subscriber is None:


### PR DESCRIPTION
Fixes #7 

Adds subscriptions to service events (via service as `serviceName/eventName`).  When subscribed, the named events published by the service are delivered to the callback specified (as is done with other event subscriptions).

This also updates the version number minor version since this is a semantic addition.  There were no API call changes, but if one relies on subscriptions to service events, one must use this version or better.

Also also, fixes minor issue where a `gradle clean` didn't remove the generated `setup.cfg` file.

