### PR TITLE
Remove data return for count -- shouldn't be there.  Enhance docs & params

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,20 +66,14 @@ on the SDK classes can be immediately awaited to run in, effectively, a synchron
 fashion, or they can return an `Awaitable` that can be _awaited_ later.
 
 ```python
-vr: VantiqResponse = await vantiq.select(VantiqResources.TYPES, 
-                                         None, 
-                                         None, 
-                                         None)
+vr: VantiqResponse = await vantiq.select(VantiqResources.TYPES)
 
 ```
 
 Alternatively,
 
 ```python
-to_await = vantiq.select(VantiqResources.TYPES, 
-                         None, 
-                         None, 
-                         None)
+to_await = vantiq.select(VantiqResources.TYPES)
 ...
 vr: VantiqResponse = await to_await
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('vantiqSdkVersion')) {
-        vantiqSdkVersion = '1.1.0'
+        vantiqSdkVersion = '1.1.1'
     }
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,7 +12,11 @@ The SDK consists of the following classes
 
 The Vantiq SDK is built atop the asyncio-based aiohttp. Consequently, operations marked as async must be awaited.
 See [the Python asyncio documentation](https://docs.python.org/3/library/asyncio.html) for more details.
+The [Coroutines and Tasks documentation](https://docs.python.org/3/library/asyncio-task.html) has examples of
+_asyncio_ Python programs.
 
+Note that some Windows environments may require the setting of the _event loop policy_.
+Please see [asyncio policy documentation](https://docs.python.org/3/library/asyncio-policy.html) for details.
 
 ## VantiqResources
 
@@ -324,7 +328,8 @@ Insert an item into Vantiq Resource.
 #### Parameters
 
 * _resource_ : str -- Name of the Vantiq resource into which to insert.
-* _instance_ : dict -- The values to be inserted.
+* _instance_ : dict -- The values to be inserted.  The key names in the _instance_ parameter 
+must match the property names in the Vantiq object.
 
 #### Returns
 
@@ -338,7 +343,8 @@ Upsert an item into Vantiq Resource.
 #### Parameters
 
 * _resource_ : str --  Name of the Vantiq resource into which to upsert.
-* _instance_ : dict -- The values to be upserted.
+* _instance_ : dict -- The values to be upserted.   The key names in the _instance_ parameter 
+must match the property names in the Vantiq object.
 
 #### Returns
 
@@ -352,7 +358,8 @@ Update an item in a Vantiq Resource.
 
 * _resource_ : str -- Name of the Vantiq resource in which to update.
 * _resource_id_ : str -- The key of the record to look up for replacement.  The _id property can be used.
-* _instance_ : dict -- The values to be updated.
+* _instance_ : dict -- The values to be updated.  The key names in the _instance_ parameter 
+must match the property names being updated in the Vantiq object.
 
 #### Returns
 
@@ -382,14 +389,14 @@ if vr.is_success:
             data = await reader.read(100)  # Read our data 100 bytes at a time
             if len(data) == 0:
                 break
-                # Do something with the data
-                ...
+            # Do something with the data
+            ...
 ```
 
 ### Vantiq.upload() (async) 
 Upload a file (or in-memory data), creating a object to hold that data.
 
-This allows the upload of a file to create a document, inage, video, or tensorflow model.
+This allows the upload of a file to create a document, image, video, or tensorflow model.
 
 #### Parameters
    
@@ -406,10 +413,10 @@ Vantiq Document. Providing both `filename` and `doc_name` in this case is an err
 
 ### Examples
 ```python
-vr: VantiqResponse = await client.upload(VantiqResources.DOCUMENTS, 'iamge/png', '/file/name.png')
+vr: VantiqResponse = await client.upload(VantiqResources.DOCUMENTS, 'image/png', 'path/name.png')
 if vr.is_success:
-    # Here, we will have uploaded a file named `/file/name.png`,
-    # and created a Document named `/file/name.png`.
+    # Here, we will have uploaded a file named `path/name.png`,
+    # and created a Document named `path/name.png`.
 
 vr: VantiqResponse = await client.upload(VantiqResource.DOCUMENTS, 'text/plain', None,
                                          'my document', 'some content for my document')
@@ -535,7 +542,9 @@ The callback message contains the following properties:
     * _path_ : str -- the event specification
     * _value_ : dict -- the value of the event (type inserted, topic contents, etc.)
     
-* _params_ : dict -- Parameters for the subscription
+* _params_ : dict -- (optional) Parameters for the subscription. May be subscription dependent,
+but can usually be ignored.
+
 
 #### Returns
 

--- a/src/main/python/vantiqsdk.py
+++ b/src/main/python/vantiqsdk.py
@@ -1047,7 +1047,7 @@ class Vantiq:
             method = 'GET'
             path = self._build_path(resource, None)
             resp = await self._perform_operation(operation, method, path, query_params, False)
-            resp.body = None  # After a count, we don't need to return the data fetched (since we decided it anyway)
+            resp.body = {}  # After a count, we don't need to return the data fetched (since we decided it anyway)
             return resp
         except VantiqException:
             # If we've already handled or wrapped it, just pass it along

--- a/src/main/python/vantiqsdk.py
+++ b/src/main/python/vantiqsdk.py
@@ -807,7 +807,8 @@ class Vantiq:
             resource : str
                 Name of the Vantiq resource into which to insert.
             instance : dict
-                The values to be inserted.
+                The values to be inserted.  The key names in the _instance_ parameter
+                must match the property names in the Vantiq object.
 
         Returns:
             VantiqResponse indicating success/failure of the operation and the value inserted.
@@ -837,7 +838,8 @@ class Vantiq:
                 resource : str
                     Name of the Vantiq resource into which to upsert.
                 instance : dict
-                    The values to be upserted.
+                    The values to be upserted.   The key names in the _instance_ parameter
+                    must match the property names in the Vantiq object.
 
             Returns:
                 VantiqResponse indicating success/failure of the operation and the value upserted.
@@ -871,7 +873,8 @@ class Vantiq:
                 resource_id : str
                     The key of the record to look up for replacement.  The _id property can be used/
                 instance : dict
-                    The values to be updated.
+                    The values to be updated. The key names in the _instance_ parameter
+                    must match the property names being updated in the Vantiq object.
 
             Returns:
                 VantiqResponse indicating success/failure of the operation and the value updated.
@@ -962,10 +965,10 @@ class Vantiq:
 
         Examples:
         ::
-            vr: VantiqResponse = await client.upload(VantiqResources.DOCUMENTS, 'iamge/png', '/file/name.png')
+            vr: VantiqResponse = await client.upload(VantiqResources.DOCUMENTS, 'iamge/png', 'path/name.png')
             if vr.is_success:
-                # Here, we will have uploaded a file named `/file/name.png`,
-                # and created a Document named `/file/name.png`.
+                # Here, we will have uploaded a file named `path/name.png`,
+                # and created a Document named `path/name.png`.
 
             vr: VantiqResponse = await client.upload(VantiqResource.DOCUMENTS, 'text/plain', None,
                                                      'my document', 'some content for my document')
@@ -1018,7 +1021,7 @@ class Vantiq:
                                   'Unexpected error during {0} operation.',
                                   ['upload']) from e
 
-    async def count(self, resource: str, where: Union[dict, None]) -> VantiqResponse:
+    async def count(self, resource: str, where: Union[dict, None] = None) -> VantiqResponse:
         """(Async) Return the number of items in a Vantiq resource that satisfy the where clause
 
         Parameters:
@@ -1044,6 +1047,7 @@ class Vantiq:
             method = 'GET'
             path = self._build_path(resource, None)
             resp = await self._perform_operation(operation, method, path, query_params, False)
+            resp.body = None  # After a count, we don't need to return the data fetched (since we decided it anyway)
             return resp
         except VantiqException:
             # If we've already handled or wrapped it, just pass it along
@@ -1220,7 +1224,7 @@ class Vantiq:
             return None
 
     async def subscribe(self, resource: str, resource_id: str, operation: Union[str, None],
-                        callback: Callable[[str, dict], Awaitable[None]], params: dict) -> VantiqResponse:
+                        callback: Callable[[str, dict], Awaitable[None]], params: dict = None) -> VantiqResponse:
         """(Async) Subscribe to an event from the Vantiq server.
 
         Subscribes to a specific topic, source, service, or type event.
@@ -1256,7 +1260,7 @@ class Vantiq:
                     value : dict -- the value of the event (type inserted, topic contents, etc.)
 
             params : dict
-                Parameters for the subscription
+                (optional) Parameters for the subscription. May be subscription dependent, but can usually be ignored.
         Returns:
             VantiqResponse indicating the success of the operation.
 

--- a/src/test/python/test_VantiqSDKLive.py
+++ b/src/test/python/test_VantiqSDKLive.py
@@ -400,7 +400,8 @@ Event.ack()"""}
         vr = await client.count(VantiqResources.DOCUMENTS)
         assert vr.count is not None
         assert vr.count == len(docs)
-        assert vr.body is None
+        assert vr.body is not None
+        assert vr.body == {}
 
         vr = await client.select_one(VantiqResources.DOCUMENTS, filename_sans_leading_slash)
         assert isinstance(vr, VantiqResponse)
@@ -464,7 +465,7 @@ Event.ack()"""}
             assert vr.is_success
             assert vr.count is not None
             assert vr.count == len(rows)
-            assert vr.body is None
+            assert vr.body == {}
 
             coroutine = client.count(VantiqResources.TYPES,
                                      {'resourceName': VantiqResources.unqualified_name(VantiqResources.TYPES)})
@@ -473,7 +474,7 @@ Event.ack()"""}
             assert vr
             assert vr.is_success
             assert vr.count == 1
-            assert vr.body is None
+            assert vr.body == {}
         except VantiqException as ve:
             traceback.print_exc()
             assert ve is None
@@ -614,7 +615,7 @@ Event.ack()"""}
                 print('Error: code: {0}, message: {1}, params: {2}'.format(err.code, err.message, err.params))
 
         assert vr.is_success
-        assert vr.body is None
+        assert vr.body == {}
         assert vr.count is not None
         old_count = vr.count
         if vr.count > 0:
@@ -645,7 +646,7 @@ Event.ack()"""}
         assert vr.is_success
         assert vr.count is not None
         assert vr.count == 1
-        assert vr.body is None
+        assert vr.body == {}
 
         # Now verify that the correct object was inserted
 

--- a/src/test/python/test_VantiqSDKLive.py
+++ b/src/test/python/test_VantiqSDKLive.py
@@ -185,7 +185,7 @@ Event.ack()"""}
 
         svc_event_id = f'{TEST_SERVICE}/{TEST_SERVICE_EVENT}'
         vr = await client.subscribe(VantiqResources.SERVICES, svc_event_id,
-                                    None, self.subscriber_callback, {})
+                                    None, self.subscriber_callback)
         assert isinstance(vr, VantiqResponse)
         self.dump_result('Subscription Error', vr)
         assert vr.is_success
@@ -397,9 +397,10 @@ Event.ack()"""}
         if not skip_pretest_cleanup:
             assert len(docs) == 3
 
-        vr = await client.count(VantiqResources.DOCUMENTS, None)
+        vr = await client.count(VantiqResources.DOCUMENTS)
         assert vr.count is not None
         assert vr.count == len(docs)
+        assert vr.body is None
 
         vr = await client.select_one(VantiqResources.DOCUMENTS, filename_sans_leading_slash)
         assert isinstance(vr, VantiqResponse)
@@ -463,6 +464,7 @@ Event.ack()"""}
             assert vr.is_success
             assert vr.count is not None
             assert vr.count == len(rows)
+            assert vr.body is None
 
             coroutine = client.count(VantiqResources.TYPES,
                                      {'resourceName': VantiqResources.unqualified_name(VantiqResources.TYPES)})
@@ -471,6 +473,7 @@ Event.ack()"""}
             assert vr
             assert vr.is_success
             assert vr.count == 1
+            assert vr.body is None
         except VantiqException as ve:
             traceback.print_exc()
             assert ve is None
@@ -611,6 +614,7 @@ Event.ack()"""}
                 print('Error: code: {0}, message: {1}, params: {2}'.format(err.code, err.message, err.params))
 
         assert vr.is_success
+        assert vr.body is None
         assert vr.count is not None
         old_count = vr.count
         if vr.count > 0:
@@ -641,6 +645,7 @@ Event.ack()"""}
         assert vr.is_success
         assert vr.count is not None
         assert vr.count == 1
+        assert vr.body is None
 
         # Now verify that the correct object was inserted
 


### PR DESCRIPTION
Fixes #10

Count should not return data -- it does since that's how select works, so remove before return.  Enhance tests to verify.

Add explanations/hints to docs.  Clarify some parameter usage.  Fix implementation to default some optional parameters.  Enhance tests to verify operation.