### PR TITLE
Update links & version for publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ in the VantiqResponse instance.
 
 ## Documentation
 
-For the full documentation on the SDK, see the [SDK API Reference](./docs/api.md).
+For the full documentation on the SDK, see the
+[SDK API Reference](https://github.com/Vantiq/vantiq-python-sdk/blob/master/docs/api.md).
 
 ## Developers
 
@@ -123,4 +124,5 @@ VANTIQ_PASSWORD <Password for that Vantiq user>
 
 ## Copyright and License
 
-Copyright &copy; 2022 Vantiq, Inc.  Code released under the [MIT license](./LICENSE.txt).
+Copyright &copy; 2022 Vantiq, Inc.  Code released under the
+[MIT license](https://github.com/Vantiq/vantiq-python-sdk/blob/master/LICENSE.txt).

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('vantiqSdkVersion')) {
-        vantiqSdkVersion = '1.1.1'
+        vantiqSdkVersion = '1.1.2'
     }
 }
 


### PR DESCRIPTION
Fixes #13

Update README.md links to full github links so the readme will work
from non-Github locations.  Updated version number in build for publication