### PR TITLE
Upgrade Python imports for Python 3.10 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'ru.vyarus.use-python' version '2.3.0'
+    id 'ru.vyarus.use-python' version '3.0.0'
 }
 
 apply plugin: 'base'
@@ -12,7 +12,7 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('vantiqSdkVersion')) {
-        vantiqSdkVersion = '1.1.2'
+        vantiqSdkVersion = '1.1.3'
     }
 }
 
@@ -21,6 +21,9 @@ python {
     pythonBinary
     // path to python binary (global by default)
     pythonPath
+    // Let pip parse the requirements to txt file
+    // use-python plugin has issues with more complex requirements.txt specifications
+    requirements.strict = false
     // additional environment variables, visible for all python commands
     // Note: We specify the directory paths to search in the pytest.ini file
     environment = [:]
@@ -56,25 +59,24 @@ python {
     // copy virtualenv instead of symlink (when created)
     envCopy = false
 
-    pip 'pip:22.0.4'
+    pip 'pip:23.1.2'
 
     // Used in product itself
-    pip 'websockets:10.2'
-    pip 'aiohttp:3.8.1'
+    pip 'websockets:11.0.3'
+    pip 'aiohttp:3.8.4'
 
     // Used for testing
-    pip 'pytest:6.2.5'
-    pip 'pytest-asyncio:0.18.3'
-    pip 'pytest-pythonpath:0.7.4'
+    pip 'pytest:7.3.1'
+    pip 'pytest-asyncio:0.21.0'
     pip 'pytest-timeout:2.1.0'
-    pip 'pytest-html:3.1.1'   // To generate html reports from pytest cases
-    pip 'aiofiles:0.8.0'
-    pip 'aioresponses:0.7.3'
+    pip 'pytest-html:3.2.0'   // To generate html reports from pytest cases
+    pip 'aiofiles:23.1.0'
+    pip 'aioresponses:0.7.4'
 
     // Used for building the distribution
-    pip 'build:0.7.0'
+    pip 'build:0.10.0'
     // For publication
-    pip 'twine:4.0.0'
+    pip 'twine:4.0.2'
 
 }
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,4 @@ minversion = 6.0
 addopts =  -rE -q --html=./build/reports/tests/test/index.html --junit-xml=./build/test-results/test/TEST-io.vantiq.vantiqsdk.pytest.xml
 asyncio_mode = strict
 testpaths = src/test/python
-python_paths =
-    src/main/python
+pythonpath = src/main/python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-aiofiles==0.8.0
-aiohttp==3.8.1
-aioresponses==0.7.3
+aiofiles==23.1.0
+aiohttp==3.8.4
+aioresponses==0.7.4
 aiosignal==1.2.0
 async-timeout==4.0.2
 attrs==21.4.0
-buiild==0.7.0
+build==0.10.0
 charset-normalizer==2.0.12
 frozenlist==1.3.0
 idna==3.3
@@ -13,17 +13,16 @@ multidict==6.0.2
 packaging==21.3
 pluggy==1.0.0
 py==1.11.0
-pytest~=7.1.1
-pytest-asyncio==0.18.3
-pytest-html==3.1.1
-pytest-pythonpath==0.7.4
+pytest~=7.3.1
+pytest-asyncio==0.21.0
+pytest-html==3.2.0
 pytest-timeout==2.1.0
 toml==0.10.2
 tomli==2.0.1
-websockets==10.2
+websockets==11.0.3
 yarl==1.7.2
 
-pip~=21.1.2
+pip~=23.1.2
 wheel~=0.36.2
 pyparsing~=3.0.8
 setuptools~=57.0.0

--- a/src/test/python/test_VantiqSDKLive.py
+++ b/src/test/python/test_VantiqSDKLive.py
@@ -184,7 +184,7 @@ Event.ack()"""}
         if self.message_checker:
             self.message_checker(what, details)
         else:
-            print('Np message checker in place for ', what, '::', details)
+            print('No message checker in place for ', what, '::', details)
 
     async def check_subscription_ops(self, client: Vantiq, prestart_transport: bool):
         if prestart_transport:

--- a/src/test/python/test_VantiqSDKLive.py
+++ b/src/test/python/test_VantiqSDKLive.py
@@ -38,8 +38,9 @@ TEST_PROCEDURE = 'pythonsdk.echo'
 TEST_TYPE = 'TestType'
 
 TEST_SERVICE = 'test.testPythonSDK.testService'
+TEST_SERVICE_TOPIC = 'test.testPythonSDK/services/testService'
 TEST_SERVICE_EVENT = 'testPythonServiceEvent'
-TEST_SERVICE_EVENT_IMPL_TOPIC = f'/topics/{TEST_SERVICE}/{TEST_SERVICE_EVENT}'
+TEST_SERVICE_EVENT_IMPL_TOPIC = f'/topics/{TEST_SERVICE_TOPIC}/{TEST_SERVICE_EVENT}'
 TEST_SERVICE_EVENT_CONTENTS = {'name': 'outbound event', 'val': {'breed': 'English Springer'}}
 TEST_SERVICE_EVENT_CONTENTS_VAIL = '{name: "outbound event", val: {breed: "English Springer"}}'
 
@@ -89,10 +90,7 @@ Event.ack()"""}
             assert vr.is_success
 
             service = {'name':  TEST_SERVICE,
-                       'eventTypes': {TEST_SERVICE_EVENT: {'direction': 'OUTBOUND',
-                                                           'implementingEventPath': TEST_SERVICE_EVENT_IMPL_TOPIC
-                                                           }
-                                      }
+                       'eventTypes': {TEST_SERVICE_EVENT: {'direction': 'OUTBOUND'}}
                        }
             vr = await client.insert(VantiqResources.SERVICES, service)
             assert vr.is_success
@@ -122,6 +120,7 @@ Event.ack()"""}
         self.callbacks = []
         self.message_checker = None
         self.last_message: Union[dict, None] = None
+        self.looking_for = None
 
     def dump_result(self, tag: str, vr: VantiqResponse):
         print(f'{tag} response: ', str(vr))
@@ -170,7 +169,12 @@ Event.ack()"""}
         assert what in ['connect', 'message']
         if what == 'message':
             assert msg['status'] < 400
-        self.last_message = msg
+        # Only save messages of interest
+        if self.looking_for is None or self.looking_for == what:
+            print('Saving message:', msg)
+            self.last_message = msg
+        else:
+            print('Not saving message: looking for', self.looking_for, ', found: ', what)
 
     async def subscriber_callback(self, what: str, details: dict) -> None:
         print('Subscriber got a callback -- what: {0}, details: {1}'.format(what, details))
@@ -178,11 +182,14 @@ Event.ack()"""}
         self.callbacks.append(what)
         if self.message_checker:
             self.message_checker(what, details)
+        else:
+            print('Np message checker in place for ', what, '::', details)
 
     async def check_subscription_ops(self, client: Vantiq, prestart_transport: bool):
         if prestart_transport:
             await client.start_subscriber_transport()
 
+        self.message_checker = self.check_callback_serviceevent_publish
         svc_event_id = f'{TEST_SERVICE}/{TEST_SERVICE_EVENT}'
         vr = await client.subscribe(VantiqResources.SERVICES, svc_event_id,
                                     None, self.subscriber_callback)
@@ -191,7 +198,6 @@ Event.ack()"""}
         assert vr.is_success
         orig_count = self.callback_count
         await asyncio.sleep(0.5)
-        self.message_checker = self.check_callback_serviceevent_publish
 
         vr = await client.execute(f'{TEST_SERVICE}.publishToOutbound', {})
         self.dump_result('Publish Service Event Error', vr)
@@ -259,6 +265,8 @@ Event.ack()"""}
 
         self.message_checker = self.check_callback_topic_publish_saveit
 
+        self.last_message = None
+        self.looking_for = 'connect'
         vr = await client.subscribe(VantiqResources.TOPICS, TEST_RELIABLE_TOPIC, None, self.subscriber_callback, params)
         self.dump_result('Subscribe to reliable', vr)
         assert vr.is_success
@@ -287,12 +295,15 @@ Event.ack()"""}
         body = {"ts": dt, 'id': f'ACK-{dt}'}
 
         self.last_message = None
+        self.looking_for = 'message'
+
         vr = await client.publish(VantiqResources.TOPICS, TEST_RELIABLE_TOPIC, body)
         assert vr.is_success
         while self.last_message is None:
             await asyncio.sleep(0.1)
 
         last = self.last_message
+        assert last is not None
         assert 'body' in last
         # noinspection PyUnresolvedReferences
         assert last['headers']['X-Request-Id'] == '/topics' + TEST_RELIABLE_TOPIC
@@ -583,9 +594,9 @@ Event.ack()"""}
         errs = vr.errors
         assert isinstance(errs, list)
         ve = errs[0]
-        assert ve.message == "The requested instance ('[name:foo]') of the k8sclusters resource could not be found."
+        assert ve.message == "The requested instance ('{name=foo}') of the k8sclusters resource could not be found."
         assert ve.code == 'io.vantiq.resource.not.found'
-        assert ve.params == ['k8sclusters', '[name:foo]']
+        assert ve.params == ['k8sclusters', '{name=foo}']
 
         vr = await client.select(VantiqResources.K8S_CLUSTERS)
         assert isinstance(vr, VantiqResponse)
@@ -626,7 +637,7 @@ Event.ack()"""}
             assert vr.count == old_count
 
         now = datetime.now()
-        dt = now.strftime('%Y-%m-%dT%H:%M:%SZ')
+        dt = now.strftime('%Y-%m-%dT%H:%M:%S.000Z')
 
         assert isinstance(dt, str)
         embedded = {'a': 1, 'b': 2}

--- a/src/test/python/test_VantiqSDKMock.py
+++ b/src/test/python/test_VantiqSDKMock.py
@@ -532,18 +532,18 @@ class TestMockedConnection:
 
         mocked.get(f'/api/v1/resources/k8sclusters/foo', status=404,
                    body=json.dumps({'code': 'io.vantiq.resource.not.found',
-                                    'message': "The requested instance ('[name:foo]') of the k8sclusters resource"
+                                    'message': "The requested instance ('{name=foo}') of the k8sclusters resource"
                                                " could not be found.",
-                                    'params': ['k8sclusters', '[name:foo]']}))
+                                    'params': ['k8sclusters', '{name=foo}']}))
         vr = await client.select_one(VantiqResources.K8S_CLUSTERS, 'foo')
         assert isinstance(vr, VantiqResponse)
         assert not vr.is_success
         errs = vr.errors
         assert isinstance(errs, list)
         ve = errs[0]
-        assert ve.message == "The requested instance ('[name:foo]') of the k8sclusters resource could not be found."
+        assert ve.message == "The requested instance ('{name=foo}') of the k8sclusters resource could not be found."
         assert ve.code == 'io.vantiq.resource.not.found'
-        assert ve.params == ['k8sclusters', '[name:foo]']
+        assert ve.params == ['k8sclusters', '{name=foo}']
 
         mocked.get('/api/v1/resources/k8sclusters', status=200, body=json.dumps([]))
 


### PR DESCRIPTION
Fixes #18 

Upgrade imports to more recent versions (generally most recent).  Pytest 6.x has compatibility issues with Python 3.10.  This should solve those.

While there, fix a few test issues having to do with Vantiq changes over time.

Changes to the python ext source sdk & connectors will follow -- same types of changes -- as will publishing this version to Pypi.