### PR TITLE
Fix dependabot warning about older pip version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('vantiqSdkVersion')) {
-        vantiqSdkVersion = '1.1.5'
+        vantiqSdkVersion = '1.2.1'
     }
 
     // See if we are using virtualenvwrapper and if so put the virtualenv in the WORKON_HOME

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ python {
     // copy virtualenv instead of symlink (when created)
     envCopy = false
     pip 'pip:23.3.1'
+    pip 'pip-tools:7.3.0'
 }
 
 tasks.register('generateRequirements', PythonTask) {

--- a/requirements-sdk.in
+++ b/requirements-sdk.in
@@ -3,3 +3,4 @@ aiohttp>=3.9.0
 urllib3>=2.0.7
 colorama>=0.4.6
 pywin32-ctypes>=0.2.2 ;  platform_system == 'Windows'
+pip>=23.3.1

--- a/requirements-sdk.in
+++ b/requirements-sdk.in
@@ -3,4 +3,3 @@ aiohttp>=3.9.0
 urllib3>=2.0.7
 colorama>=0.4.6
 pywin32-ctypes>=0.2.2 ;  platform_system == 'Windows'
-pip>=23.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,23 +18,18 @@ async-timeout==4.0.3
     # via aiohttp
 attrs==23.1.0
     # via aiohttp
-bleach==6.0.0
-    # via readme-renderer
-build==0.10.0
+build==1.0.3
     # via
     #   -r requirements-build.in
     #   pip-tools
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via requests
-click==8.1.6
+click==8.1.7
     # via pip-tools
 colorama==0.4.6
-    # manually via
-    #   build
-    #   click
-    #   pytest
+    # via -r requirements-sdk.in
 docutils==0.20.1
     # via readme-renderer
 exceptiongroup==1.2.0
@@ -43,7 +38,7 @@ frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
-idna==3.4
+idna==3.6
     # via
     #   requests
     #   yarl
@@ -55,10 +50,14 @@ iniconfig==2.0.0
     # via pytest
 jaraco-classes==3.3.0
     # via keyring
-keyring==24.2.0
+jinja2==3.1.2
+    # via pytest-html
+keyring==24.3.0
     # via twine
 markdown-it-py==3.0.0
     # via rich
+markupsafe==2.1.3
+    # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.1.0
@@ -67,7 +66,9 @@ multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-packaging==23.1
+nh3==0.2.14
+    # via readme-renderer
+packaging==23.2
     # via
     #   build
     #   pytest
@@ -77,15 +78,15 @@ pip-tools==7.3.0
     # via -r requirements-build.in
 pkginfo==1.9.6
     # via twine
-pluggy==1.2.0
+pluggy==1.3.0
     # via pytest
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   readme-renderer
     #   rich
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.0
+pytest==7.4.3
     # via
     #   -r requirements-build.in
     #   pytest-asyncio
@@ -94,15 +95,15 @@ pytest==7.4.0
     #   pytest-timeout
 pytest-asyncio==0.21.1
     # via -r requirements-build.in
-pytest-html==3.2.0
+pytest-html==4.1.1
     # via -r requirements-build.in
 pytest-metadata==3.0.0
     # via pytest-html
-pytest-timeout==2.1.0
+pytest-timeout==2.2.0
     # via -r requirements-build.in
-pywin32-ctypes==0.2.2 ;  platform_system == 'Windows'
-    # Manual add for Windows cases
-readme-renderer==40.0
+pywin32-ctypes>=0.2.2 ;  platform_system == 'Windows'
+    # Manually added for windows support
+readme-renderer==42.0
     # via twine
 requests==2.31.0
     # via
@@ -112,12 +113,10 @@ requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.5.2
+rich==13.7.0
     # via twine
-setuptools==68.1.0
+setuptools==69.0.2
     # via pip-tools
-six==1.16.0
-    # via bleach
 tomli==2.0.1
     # via
     #   build
@@ -131,16 +130,11 @@ urllib3==2.1.0
     #   -r requirements-sdk.in
     #   requests
     #   twine
-webencodings==0.5.1
-    # via bleach
 websockets==12.0
     # via -r requirements-sdk.in
-wheel==0.41.1
+wheel==0.42.0
     # via pip-tools
-yarl==1.9.2
+yarl==1.9.3
     # via aiohttp
-zipp==3.16.2
+zipp==3.17.0
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# py

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ packaging==23.1
     # via
     #   build
     #   pytest
-pip==23.2.1
+pip==23.3.1
     # via pip-tools
 pip-tools==7.3.0
     # via -r requirements-build.in


### PR DESCRIPTION
Which we weren't really using but was listed in requirements.  Updated a few other dependencies in the process...

No issue reported. 

Will update version number to 1.2 since change to python version