### PR TITLE
Upgrade jinja to fix CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('vantiqSdkVersion')) {
-        vantiqSdkVersion = '1.2.5'
+        vantiqSdkVersion = '1.2.6'
     }
 
     // See if we are using virtualenvwrapper and if so put the virtualenv in the WORKON_HOME

--- a/requirements-build.in
+++ b/requirements-build.in
@@ -6,6 +6,9 @@ pytest-timeout
 aiofiles
 aioresponses>=0.7.6
 
+# Dependabot fix
+jinja2>=3.1.4
+
 # For build
 pip-tools
 build

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ aioresponses==0.7.6
     # via -r requirements-build.in
 aiosignal==1.3.1
     # via aiohttp
+async-timeout==4.0.3
+    # via aiohttp
 attrs==23.1.0
     # via aiohttp
 build==1.0.3
@@ -26,14 +28,10 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via pip-tools
-colorama==0.4.6 ; platform_system == "Windows"
-    # via
-    #   -r requirements-build.in
-    #   build
-    #   click
-    #   pytest
 docutils==0.20.1
     # via readme-renderer
+exceptiongroup==1.2.1
+    # via pytest
 frozenlist==1.4.0
     # via
     #   aiohttp
@@ -50,8 +48,10 @@ iniconfig==2.0.0
     # via pytest
 jaraco-classes==3.3.0
     # via keyring
-jinja2==3.1.2
-    # via pytest-html
+jinja2==3.1.4
+    # via
+    #   -r requirements-build.in
+    #   pytest-html
 keyring==24.3.0
     # via twine
 markdown-it-py==3.0.0
@@ -101,10 +101,6 @@ pytest-metadata==3.0.0
     # via pytest-html
 pytest-timeout==2.2.0
     # via -r requirements-build.in
-pywin32-ctypes==0.2.2 ; platform_system == "Windows"
-    # via
-    #   -r requirements-build.in
-    #   keyring
 readme-renderer==42.0
     # via twine
 requests==2.31.0
@@ -119,6 +115,12 @@ rich==13.7.0
     # via twine
 setuptools==69.5.1
     # via pip-tools
+tomli==2.0.1
+    # via
+    #   build
+    #   pip-tools
+    #   pyproject-hooks
+    #   pytest
 twine==4.0.2
     # via -r requirements-build.in
 urllib3==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,12 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via pip-tools
+colorama==0.4.6 ; platform_system == "Windows"
+    # via
+    #   -r requirements-build.in
+    #   build
+    #   click
+    #   pytest
 docutils==0.20.1
     # via readme-renderer
 exceptiongroup==1.2.1
@@ -101,6 +107,11 @@ pytest-metadata==3.0.0
     # via pytest-html
 pytest-timeout==2.2.0
     # via -r requirements-build.in
+pywin32-ctypes==0.2.2 ; platform_system == "Windows"
+    # via
+    #   -r requirements-build.in
+    #   keyring
+118,123d121
 readme-renderer==42.0
     # via twine
 requests==2.31.0

--- a/src/test/python/test_VantiqSDKLive.py
+++ b/src/test/python/test_VantiqSDKLive.py
@@ -603,7 +603,7 @@ Event.ack()"""}
         assert isinstance(vr, VantiqResponse)
         assert vr.is_success
         rows = vr.body
-        assert len(rows) == 0
+        assert len(rows) == 1
 
         vr = await client.select('system.junkola')
         assert isinstance(vr, VantiqResponse)


### PR DESCRIPTION
Upgrade jinja for dependabot inspired fix for CVE.

Also fix cluster count for staging-based tests