### PR TITLE
Add support for targetNamespace to subscribe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('vantiqSdkVersion')) {
-        vantiqSdkVersion = '1.2.6'
+        vantiqSdkVersion = '1.3.0'
     }
 
     // See if we are using virtualenvwrapper and if so put the virtualenv in the WORKON_HOME


### PR DESCRIPTION
Also added the ability to install a handler which is called when the subscriber's connection is terminated.  Improved cleanup in this case to make sure subscriber is reset to "disconnected" state.

Added support for protocol being added in 1.39 to indicate when the server side removes a subscription (typically due to the removal of a namespace).

Fixes #38