### PR TITLE
Enclose event read loop in try/finally to ensure close is done

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('vantiqSdkVersion')) {
-        vantiqSdkVersion = '1.3.5'
+        vantiqSdkVersion = '1.3.6'
     }
 
     // See if we are using virtualenvwrapper and if so put the virtualenv in the WORKON_HOME

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('vantiqSdkVersion')) {
-        vantiqSdkVersion = '1.3.6'
+        vantiqSdkVersion = '1.3.7'
     }
 
     // See if we are using virtualenvwrapper and if so put the virtualenv in the WORKON_HOME


### PR DESCRIPTION
This ensures that we handle both close cases that exit the loop normally and those (like ping timeout) that result in an exception.

Fixes #51 