### PR TITLE
Pass additional connection arguments to aiohttp & websocket calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('vantiqSdkVersion')) {
-        vantiqSdkVersion = '1.3.7'
+        vantiqSdkVersion = '1.4.0'
     }
 
     // See if we are using virtualenvwrapper and if so put the virtualenv in the WORKON_HOME

--- a/docs/api.md
+++ b/docs/api.md
@@ -134,6 +134,11 @@ Create a Vantiq client object.
 
 * _server_ : str -- URL String at which to find the Vantiq Server
 * _api_version_ : str (optional) -- Version of the API to use. Defaults to '1'
+* ... : After the _api_version_ parameter, you can provide a list of keyword arguments. These will be passed to the
+        `aiohttp.client.ClientSession` connection's `get()`, `post()`, `put()`, and `delete()` calls and,
+         in the case of a subscription, the `websockets.connect()` call. This allows a caller to modify the connection
+         as required.  A typical use case would be for disabling SSL certificate checking for test environments using
+         self-signed certificates.
 
 #### Returns
     Vantiq object with which to interact with the Vantiq system.
@@ -153,6 +158,14 @@ Or, in a client object:
 
 ```python
     client = Vantiq('https://dev.vantiq.com')
+    ...
+    await client.close()
+```
+
+Or, in a client object with SSL checking disabled:
+
+```python
+    client = Vantiq('https://dev.vantiq.com', 1, ssl=False)
     ...
     await client.close()
 ```

--- a/src/test/python/test_VantiqSDKLive.py
+++ b/src/test/python/test_VantiqSDKLive.py
@@ -970,6 +970,18 @@ Event.ack()"""}
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(10)
+    async def test_subscriptions_as_plain_client_ignore_ssl_no_version(self):
+        self.check_test_conditions()
+        client = Vantiq(_server_url, ssl=False)
+        if _access_token:
+            await client.set_access_token(_access_token)
+        else:
+            await client.authenticate(_username, _password)
+        await self.check_subscription_ops(client, False)
+        await client.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(10)
     async def test_subscriptions_as_plain_client_ssl_context(self):
         self.check_test_conditions()
         context = ssl.create_default_context()


### PR DESCRIPTION
Fixes #54

When working in test environments, it's often the case that SSL certificates are self-signed or otherwise not up to full validation.  

To enable operation in these cases, we add the ability to pass keyword arguments to the Vantiq() call.  These arguments are not validated, but are passed along to the appropriate `aiohttp.ClientSession` and `websocket.connect()` calls (for subscriptions).  This allows the caller access to the various connection configuration options they'd have if they were doing the connection themselves.