### PR TITLE
Remove pinned versions to avoid downstream issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('vantiqSdkVersion')) {
-        vantiqSdkVersion = '1.4.7'
+        vantiqSdkVersion = '1.4.8'
     }
 
     // See if we are using virtualenvwrapper and if so put the virtualenv in the WORKON_HOME

--- a/requirements-sdk.in
+++ b/requirements-sdk.in
@@ -7,6 +7,6 @@
 # Also avoid putting any libraries that are only used by the build system (directly or
 # indirectly).  Those belong in "requirements-build.in".
 websockets
-requests>=2.32.3
-urllib3>=2.5.0
-aiohttp>=3.12.14
+requests
+urllib3
+aiohttp


### PR DESCRIPTION
The GenAI Flow Service cannot uptake later versions of urllib3 so we need to avoid pinning it here